### PR TITLE
Allow terp args to be passed to regtest.py

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -1123,7 +1123,9 @@ if (not gamefile):
     sys.exit(-1)
 
 if (opts.terppath):
-    terppath = opts.terppath
+    subls = opts.terppath.split()
+    terppath = subls[0]
+    terpargs = subls[1:]
 if (not terppath):
     print('No interpreter path specified')
     sys.exit(-1)


### PR DESCRIPTION
Allow terp args to be passed to regtest.py, and not only by a line in the regtest file itself.

Makes it easier to run the same test suite in multiple terps or with different terp options